### PR TITLE
Change 'complet' to 'complete' for consistency

### DIFF
--- a/Export_Trakt_4_Letterboxd.sh
+++ b/Export_Trakt_4_Letterboxd.sh
@@ -88,7 +88,7 @@ refresh_access_token() {
 if [ ! -z $1 ]
 	then
 	OPTION=$(echo $1 | tr '[:upper:]' '[:lower:]')
-	if [ $OPTION == "complet" ]
+	if [ $OPTION == "complete" ]
 		then
 		echo -e "${SAISPAS}${BOLD}[`date`] - Complete Mode activated${NC}" | tee -a "${LOG}"
     endpoints=(
@@ -193,7 +193,7 @@ done
 
 echo -e "All files have been retrieved\n Starting processing" | tee -a "${LOG}"
 
-if [ $OPTION == "complet" ]
+if [ $OPTION == "complete" ]
 	then
 # compress backup folder
 echo -e "Compressing backup..." | tee -a "${LOG}"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project allows you to export your Trakt.tv data to a format compatible with
    ```bash
    ./Export_Trakt_4_Letterboxd.sh [option]
    ```
-   Options: `normal` (default), `initial`, or `complet`
+   Options: `normal` (default), `initial`, or `complete`
 
 ### Docker Installation
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -180,7 +180,7 @@ echo ""
 echo "Options for Export_Trakt_4_Letterboxd.sh:"
 echo "  normal (default) - Export rated movies, episodes, history, and watchlist"
 echo "  initial - Export only rated and watched movies"
-echo "  complet - Export all available data"
+echo "  complete - Export all available data"
 echo ""
 
 # Execute command if provided, otherwise keep container running

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -58,7 +58,7 @@ Available options:
 
 - `normal` (default): Exports rated movies, rated episodes, movie and TV show history, and watchlist
 - `initial`: Exports only rated and watched movies
-- `complet`: Exports all available data
+- `complete`: Exports all available data
 
 ### Result
 

--- a/docs/DOCKER_USAGE.md
+++ b/docs/DOCKER_USAGE.md
@@ -126,7 +126,7 @@ The Docker container uses the following volumes to persist data:
 You can configure the Docker container to automatically run the export script on a schedule using cron. To enable this feature, set the following environment variables:
 
 - `CRON_SCHEDULE`: The cron schedule expression (e.g., `0 3 * * *` for daily at 3:00 AM)
-- `EXPORT_OPTION`: The export option to use (`normal`, `initial`, or `complet`)
+- `EXPORT_OPTION`: The export option to use (`normal`, `initial`, or `complete`)
 
 ### Example with Docker Compose:
 


### PR DESCRIPTION
# Pull Request: Change 'complet' to 'complete' for consistency

## Description
This Pull Request changes the French term "complet" to its English equivalent "complete" throughout the codebase for better linguistic consistency and to fix issues with the complete export option.

## Changes
- Modified `Export_Trakt_4_Letterboxd.sh` to use "complete" instead of "complet" in conditional statements
- Updated `docker-entrypoint.sh` help message to display "complete" instead of "complet"
- Updated documentation in `README.md` to reflect the correct option name
- Updated export option descriptions in `CONFIGURATION.md` and `DOCKER_USAGE.md`

## Motivation
The codebase was inconsistently using both "complet" (French) and "complete" (English) in different places, which could cause confusion and potential bugs when users tried to use the complete export option. This PR standardizes on the English term "complete" throughout the codebase.

## Testing
- Verified that the "complete" export option works correctly
- Confirmed that all documentation consistently refers to the option as "complete"
- Tested that the Docker container correctly displays "complete" in the help message

## Related Issues
Fixes an inconsistency where the export option was referred to as both "complet" and "complete" in different parts of the codebase.
