### PR TITLE
Add README badges and Docker image to GitHub releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
       # This is used to complete the identity challenge
       # with sigstore/fulcio when running outside of PRs.
@@ -99,6 +99,14 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          outputs: type=docker,dest=/tmp/docker-image.tar
+
+      # Export Docker image for release
+      - name: Export Docker image
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/release
+          gzip -c /tmp/docker-image.tar > /tmp/release/docker-image.tar.gz
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker
@@ -114,3 +122,29 @@ jobs:
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+
+      # Create a release when merged to main
+      - name: Create release
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: "Release ${{ github.run_number }}"
+          tag_name: "v0.1.${{ github.run_number }}"
+          draft: false
+          prerelease: false
+          files: |
+            /tmp/release/docker-image.tar.gz
+          body: |
+            This release includes the latest Docker image for Export Trakt 4 Letterboxd.
+
+            ### Docker Image
+            The Docker image is attached as an asset and can be loaded with:
+            ```bash
+            gunzip -c docker-image.tar.gz | docker load
+            ```
+
+            Or directly pull from GitHub Container Registry:
+            ```bash
+            docker pull ghcr.io/${{ github.repository }}:latest
+            ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Export Trakt 4 Letterboxd
 
+[![GitHub release](https://img.shields.io/github/v/release/JohanDevl/Export_Trakt_4_Letterboxd)](https://github.com/JohanDevl/Export_Trakt_4_Letterboxd/releases)
+[![GitHub stars](https://img.shields.io/github/stars/JohanDevl/Export_Trakt_4_Letterboxd)](https://github.com/JohanDevl/Export_Trakt_4_Letterboxd/stargazers)
+[![GitHub issues](https://img.shields.io/github/issues/JohanDevl/Export_Trakt_4_Letterboxd)](https://github.com/JohanDevl/Export_Trakt_4_Letterboxd/issues)
+[![GitHub license](https://img.shields.io/github/license/JohanDevl/Export_Trakt_4_Letterboxd)](https://github.com/JohanDevl/Export_Trakt_4_Letterboxd/blob/main/LICENSE)
+[![Docker Build](https://github.com/JohanDevl/Export_Trakt_4_Letterboxd/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/JohanDevl/Export_Trakt_4_Letterboxd/actions/workflows/docker-publish.yml)
+[![Docker Package](https://img.shields.io/badge/Docker-ghcr.io-blue?logo=docker)](https://github.com/JohanDevl/Export_Trakt_4_Letterboxd/pkgs/container/export_trakt_4_letterboxd)
+[![GitHub package size](https://img.shields.io/github/repo-size/JohanDevl/Export_Trakt_4_Letterboxd?logo=docker&label=Image%20Size)](https://github.com/JohanDevl/Export_Trakt_4_Letterboxd/pkgs/container/export_trakt_4_letterboxd)
+[![Trakt.tv](https://img.shields.io/badge/Trakt.tv-ED1C24?logo=trakt&logoColor=white)](https://trakt.tv)
+[![Letterboxd](https://img.shields.io/badge/Letterboxd-00D735?logo=letterboxd&logoColor=white)](https://letterboxd.com)
+
 This project allows you to export your Trakt.tv data to a format compatible with Letterboxd.
 
 ## Quick Start


### PR DESCRIPTION
## Problem Solved
This PR adds project badges to README.md and implements GitHub release functionality that automatically attaches the Docker image as a release asset when merges to the main branch occur.

### Changes Made
1. Added multiple badges to README.md to provide better project status visibility:
   - GitHub release badge
   - Stars and issues counters
   - License badge
   - Docker build status
   - Docker package link
   - Repository size badge
   - Trakt.tv and Letterboxd badges

2. Modified GitHub Actions workflow to:
   - Export the Docker image as a tarball
   - Create a GitHub release when code is merged into main branch
   - Attach the Docker image as a release asset
   - Add instructions for using the Docker image in the release notes

### Impact
- Improved README presentation with informative badges
- Automated GitHub releases with properly versioned tags
- Made Docker images directly downloadable as release assets
- Added clear instructions for Docker image usage in release notes

### Testing
These changes don't affect the core functionality of the application. The workflow changes will be tested automatically on the next merge to the main branch.