### PR TITLE
Add version information to Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -50,6 +52,20 @@ jobs:
         uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
         with:
           cosign-release: "v2.2.4"
+
+      # Get version information for main branch
+      - name: Get version info
+        id: version
+        if: github.ref == 'refs/heads/main'
+        run: |
+          # Get latest version tag
+          LATEST_TAG=$(git tag -l "v*" | grep -v "-" | sort -V | tail -n 1)
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v1.0.0"
+          fi
+          # Store the version without the 'v' prefix
+          VERSION=${LATEST_TAG#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
@@ -100,6 +116,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=/tmp/docker-image.tar
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.version || 'develop' }}
 
       # Export Docker image for release
       - name: Export Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM alpine:3.18
 
+# Define build arguments for version
+ARG APP_VERSION=dev
+
+# Add version labels
+LABEL org.opencontainers.image.version=$APP_VERSION \
+      org.opencontainers.image.title="Export Trakt 4 Letterboxd" \
+      org.opencontainers.image.description="Tool for exporting Trakt.tv history to Letterboxd compatible format"
+
 # Install required packages
 RUN apk add --no-cache \
     bash \
@@ -32,7 +40,8 @@ ENV DOSLOG=/app/logs \
     BACKUP_DIR=/app/backup \
     CONFIG_DIR=/app/config \
     CRON_SCHEDULE="" \
-    EXPORT_OPTION="normal"
+    EXPORT_OPTION="normal" \
+    APP_VERSION=$APP_VERSION
 
 # Set volume for persistent data
 VOLUME ["/app/logs", "/app/copy", "/app/backup", "/app/config"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,6 +16,11 @@ log_message() {
     esac
 }
 
+# Show version information
+show_version() {
+    log_message "INFO" "Starting Export Trakt 4 Letterboxd container - Version: ${APP_VERSION:-unknown}"
+}
+
 # Debug function for file and directory information
 debug_file_info() {
     local path="$1"
@@ -61,6 +66,7 @@ debug_file_info() {
 
 # Initial system information
 log_message "INFO" "Starting Docker container for Export_Trakt_4_Letterboxd"
+show_version
 log_message "DEBUG" "Container environment:"
 log_message "DEBUG" "User: $(id)"
 log_message "DEBUG" "Working directory: $(pwd)"


### PR DESCRIPTION
## Changes

This PR adds version information to Docker images:

- Added version retrieval step in GitHub workflow to get the latest tag version
- Pass the version as a build argument to Docker
- Added ARG and LABEL in Dockerfile to store version information
- Expose version via environment variable in container
- Display version on container startup

When a Docker image is published from the main branch, it will include the current project version visible in container metadata and displayed during container startup.

## Testing

- [x] Verified Docker build arguments are correctly passed
- [x] Verified version information is added to Docker image metadata
- [x] Verified version is displayed on container startup