### PR TITLE
Fix: Add explicit version tag for Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -100,6 +100,8 @@ jobs:
             type=ref,event=branch
             # Add 'latest' tag for main branch
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            # Add version tag for main branch (like main-1.2.3)
+            type=raw,value=main-${{ steps.version.outputs.version }},enable=${{ github.ref == 'refs/heads/main' && steps.version.outputs.version != '' }}
             # Add 'develop' tag for develop branch
             type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
 


### PR DESCRIPTION
## Changes

This PR adds an explicit version tag for Docker images built from the main branch. When the workflow runs on the main branch, it will now generate an additional tag in the format `main-X.Y.Z` (e.g., `main-1.2.3`).

## Benefits
- Better visibility of the version associated with the main branch image
- Easier tracking of which version is currently deployed
- Allows referencing specific version of main builds

## Implementation
- Added a new tag pattern in the docker-publish.yml workflow
- The tag combines "main-" prefix with the current version number
- Only applies when building from the main branch and when a version is available

This change complements the previous modifications to include version information inside the Docker images.