### PR TITLE
Fix: Change version tag format to vX.Y.Z

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -100,8 +100,8 @@ jobs:
             type=ref,event=branch
             # Add 'latest' tag for main branch
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            # Add version tag for main branch (like main-1.2.3)
-            type=raw,value=main-${{ steps.version.outputs.version }},enable=${{ github.ref == 'refs/heads/main' && steps.version.outputs.version != '' }}
+            # Add version tag for main branch (like v1.2.3)
+            type=raw,value=v${{ steps.version.outputs.version }},enable=${{ github.ref == 'refs/heads/main' && steps.version.outputs.version != '' }}
             # Add 'develop' tag for develop branch
             type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
 


### PR DESCRIPTION
## Changes

This PR changes the version tag format to follow the standard semantic versioning format with a "v" prefix. When the workflow runs on the main branch, it will now generate an additional tag in the format `vX.Y.Z` (e.g., `v1.2.3`).

## Benefits
- Standard versioning format with "v" prefix
- Consistent with Git tags format
- Better integration with semantic versioning tools

## Implementation
- Updated the tag pattern in the docker-publish.yml workflow
- Changed format from `main-X.Y.Z` to `vX.Y.Z`
- Tag is still only applied when building from the main branch and when a version is available

This change ensures Docker image tags follow the same versioning convention as the Git repository tags.