### PR TITLE
Fix Docker build by adding locales directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /build
 
 # Copy only necessary build files first
 COPY lib/ /build/lib/
+COPY locales/ /build/locales/
 COPY Export_Trakt_4_Letterboxd.sh setup_trakt.sh install.sh /build/
 
 # Make scripts executable
@@ -67,12 +68,9 @@ ENV DOSLOG=/app/logs \
 # Set volume for persistent data
 VOLUME ["/app/logs", "/app/copy", "/app/backup", "/app/config"]
 
-# Switch to non-root user for normal operation, but keep root for cron
-# USER appuser
-
 # Health check
 HEALTHCHECK --interval=1m --timeout=10s --start-period=30s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
 # Set entrypoint
-ENTRYPOINT ["/app/docker-entrypoint.sh"] 
+ENTRYPOINT ["/app/docker-entrypoint.sh"]


### PR DESCRIPTION
## Description
This PR fixes the Docker build error shown in PR #31 tests.

### Problem
When running the Docker container, the following error was occurring:
```
ERROR: Required module not found: config.sh
```

### Root Cause
The error was happening because the Docker image was missing the `locales` directory. When the script tries to initialize internationalization, it looks for language files in this directory, which triggers loading the config module. Since no language files were found, it was displaying an error about the missing module.

### Fix
- Added the `locales` directory to the Docker build process by adding `COPY locales/ /build/locales/` to the Dockerfile

### Testing
The Docker build should now complete successfully and the container should start properly.