### PR TITLE
Add vX.Y.Z Docker image tag format

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -137,6 +137,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            # Also add the vX.Y.Z format
+            type=semver,pattern=v{{version}}
             # For branch-based tagging
             type=ref,event=branch
             # Add 'latest' tag for main branch


### PR DESCRIPTION
## Description
This PR adds the vX.Y.Z tag format to Docker images in addition to existing formats. This will allow for explicit references to versions including the 'v' prefix.

## Changes
- Added `type=semver,pattern=v{{version}}` pattern in Docker metadata configuration

## Impact
- Docker images will now also be tagged with the vX.Y.Z format
- Improves consistency between Git tags and Docker tags

## Tests
- Docker build workflow is functional
- Tags generated as expected during releases