### PR TITLE
Add vX.Y.Z format for Docker image tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -145,6 +145,8 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             # Add 'develop' tag for develop branch
             type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
+            # Add explicit vX.Y.Z tag for version tags
+            type=raw,value=v${{ steps.version.outputs.version }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       # Debug step to see metadata output
       - name: Debug metadata


### PR DESCRIPTION
## Description
This PR adds the vX.Y.Z tag format to Docker images in addition to existing formats. This ensures explicit references to versions including the 'v' prefix, maintaining consistency between Git tags and Docker image tags.

## Changes
- Added `type=semver,pattern=v{{version}}` pattern in Docker metadata configuration
- Added explicit raw tag generation with `type=raw,value=v${{ steps.version.outputs.version }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}`

## Impact
- Docker images will now also be tagged with the vX.Y.Z format when building from version tags
- Improves consistency between Git tags and Docker tags
- Makes it easier to reference specific versioned Docker images with the same format as Git tags

## Tests
- Docker build workflow will generate the vX.Y.Z tag format when building from version tags