### PR TITLE
Add explicit vX.Y.Z tags for Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -147,6 +147,9 @@ jobs:
             type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
             # Add explicit vX.Y.Z tag for version tags
             type=raw,value=v${{ steps.version.outputs.version }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            # Add explicit v-prefixed tags for all builds
+            type=raw,value=v1.2.0,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=vdev,enable=${{ github.ref == 'refs/heads/develop' }}
 
       # Debug step to see metadata output
       - name: Debug metadata


### PR DESCRIPTION
## Description
This PR adds explicit vX.Y.Z format tags to Docker images for all branches to ensure consistent version tagging:

- `v1.2.0` tag for the `main` branch
- `vdev` tag for the `develop` branch
- Preserves the existing tag formats

## Changes
Added two explicit v-prefixed tags to the Docker metadata configuration:
```yaml
# Add explicit v-prefixed tags for all builds
type=raw,value=v1.2.0,enable=${{ github.ref == 'refs/heads/main' }}
type=raw,value=vdev,enable=${{ github.ref == 'refs/heads/develop' }}
```

## Benefits
- Provides consistent v-prefixed version tags regardless of build source
- Makes it easier to reference images with a format that matches Git tags
- No need to wait for a version tag to be pushed to get v-prefixed Docker tags

## Testing
Once merged, the next build from any branch will include these explicit tags.