### PR TITLE
Add v-prefixed Docker tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -147,6 +147,9 @@ jobs:
             type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
             # Add explicit vX.Y.Z tag for version tags
             type=raw,value=v${{ steps.version.outputs.version }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            # Add explicit v-prefixed tags for all builds
+            type=raw,value=v${{ steps.version.outputs.version }},enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=vdev,enable=${{ github.ref == 'refs/heads/develop' }}
 
       # Debug step to see metadata output
       - name: Debug metadata


### PR DESCRIPTION
## Description
This PR adds v-prefixed Docker image tags to ensure consistent version tagging across both GitHub Container Registry and Docker Hub.

## Changes
- Added `type=semver,pattern=v{{version}}` to generate v-prefixed tags for semantic version tags
- Added explicit v-prefixed tags for branch-based builds:
  - `v${{ steps.version.outputs.version }}` for the main branch
  - `vdev` for the develop branch

## Benefits
- Provides consistent v-prefixed version tags for all builds
- Improves compatibility with systems expecting v-prefixed versioning
- Makes it easier to reference specific Docker image versions with a format that matches Git tags

## Testing
The workflow has been tested and confirmed to generate the appropriate v-prefixed tags.