### PR TITLE
fix: change OAuth authentication link to open in same tab

### DIFF
--- a/web/templates/auth-url.html
+++ b/web/templates/auth-url.html
@@ -47,7 +47,7 @@
         </div>
         
         <div class="auth-action">
-            <a href="{{.AuthURL}}" target="_blank" class="btn btn-primary btn-large">
+            <a href="{{.AuthURL}}" target="_self" class="btn btn-primary btn-large">
                 🔗 Authenticate with Trakt.tv
             </a>
         </div>


### PR DESCRIPTION
## Summary

- Change OAuth authentication link from `target="_blank"` to `target="_self"` in auth-url.html template
- Improves user experience by opening authentication in the same tab instead of a new window
- Allows users to naturally return to the application after OAuth callback completion

## Changes Made

- Modified `web/templates/auth-url.html:50` to use `target="_self"` instead of `target="_blank"`
- No functional changes to authentication flow, only improved navigation behavior

## Test Plan

- [ ] Verify authentication page loads correctly
- [ ] Click "Authenticate with Trakt.tv" button opens in same tab
- [ ] Complete OAuth flow and verify callback returns to application
- [ ] Test across different browsers (Chrome, Firefox, Safari)
- [ ] Verify no regression in authentication functionality

## Impact

**User Experience:**
- Eliminates need for popup window handling
- Provides smoother navigation flow
- Reduces browser compatibility issues with popup blockers

**Technical:**
- Single line change with minimal risk
- No impact on OAuth security or functionality
- Maintains existing callback handling logic